### PR TITLE
Use the same API for Oauth2 authentication as in BrowserBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ The following connection options can be used with `simplesmtp.connect`:
 
   * **useSSL** *Boolean* Set to true, to use encrypted connection
   * **name** *String* Client hostname for introducing itself to the server
-  * **auth** *Object* Authentication options. Depends on the preferred authentication method. Usually `{user, pass}`
+  * **auth** *Object* Authentication options. Depends on the preferred authentication method
+    * **user** is the username for the user (also applies to OAuth2)
+    * **pass** is the password for the user if plain auth is used
+    * **xoauth2** is the OAuth2 access token to be used instead of password. If both password and xoauth2 token are set, the token is preferred.
   * **authMethod** *String* Force specific authentication method (eg. `"PLAIN"` for using `AUTH PLAIN` or `"XOAUTH2"` for `AUTH XOAUTH2`)
   * **disableEscaping** *Boolean* If set to true, do not escape dots on the beginning of the lines
   * **logLength** *Number* How many messages between the client and the server to log. Set to false to disable logging. Defaults to 6
@@ -73,10 +76,9 @@ To authenticate using XOAUTH2, use the following authentication config
 
 ```javascript
 var config = {
-    authMethod: 'XOAUTH2',
     auth: {
       user: 'username',
-      token: 'access_token'
+      xoauth2: 'access_token'
   }
 };
 ```

--- a/src/smtpclient.js
+++ b/src/smtpclient.js
@@ -447,7 +447,7 @@
      * @param {Object} command Parsed data
      */
     SmtpClient.prototype._onCommand = function(command) {
-        if(typeof this._currentAction === 'function'){
+        if (typeof this._currentAction === 'function') {
             this._currentAction.call(this, command);
         }
     };
@@ -537,6 +537,10 @@
 
         var auth;
 
+        if (!this.options.authMethod && this.options.auth.xoauth2) {
+            this.options.authMethod = 'XOAUTH2';
+        }
+
         if (this.options.authMethod) {
             auth = this.options.authMethod.toUpperCase().trim();
         } else {
@@ -569,7 +573,7 @@
             case 'XOAUTH2':
                 // See https://developers.google.com/gmail/xoauth2_protocol#smtp_protocol_exchange
                 this._currentAction = this._actionAUTH_XOAUTH2;
-                this._sendCommand('AUTH XOAUTH2 ' + this._buildXOAuth2Token(this.options.auth.user, this.options.auth.token));
+                this._sendCommand('AUTH XOAUTH2 ' + this._buildXOAuth2Token(this.options.auth.user, this.options.auth.xoauth2));
                 return;
         }
 

--- a/test/unit/smtpclient-test.js
+++ b/test/unit/smtpclient-test.js
@@ -412,10 +412,9 @@ define(function(require) {
 
                 smtp.options.auth = {
                     user: 'abc',
-                    token: 'def'
+                    xoauth2: 'def'
                 };
                 smtp._supportedAuth = ['XOAUTH2'];
-                smtp.options.authMethod = 'XOAUTH2';
                 smtp._authenticateUser();
 
                 expect(_sendCommandStub.withArgs('AUTH XOAUTH2 dXNlcj1hYmMBYXV0aD1CZWFyZXIgZGVmAQE=').callCount).to.equal(1);


### PR DESCRIPTION
NB! Breaks current usage (change `token` -> `xoauth2`). `authMethod` is detected automatically and does not need to be set anymore.
