### PR TITLE
Fix bug with XOAUTH2

### DIFF
--- a/src/smtpclient.js
+++ b/src/smtpclient.js
@@ -686,7 +686,7 @@
             this._sendCommand('');
             this._currentAction = this._actionAUTHComplete;
         } else {
-            this._currentAction = this._actionAUTHComplete(command);
+            this._actionAUTHComplete(command);
         }
     };
 


### PR DESCRIPTION
`_actionAUTHComplete` returns undefined, so `_currentAction` was unintentionally cleared
