### PR TITLE
[WO-612] Implemented requireTLS option to explicitly require STARTTLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The following connection options can be used with `simplesmtp.connect`:
   * **disableEscaping** *Boolean* If set to true, do not escape dots on the beginning of the lines
   * **logLength** *Number* How many messages between the client and the server to log. Set to false to disable logging. Defaults to 6
   * **ignoreTLS** – if set to true, do not issue STARTTLS even if the server supports it
+  * **requireTLS** – if set to true, always use STARTTLS before authentication even if the host does not advertise it. If STARTTLS fails, do not try to authenticate the user
+
+Default STARTTLS support is opportunistic – if the server advertises STARTTLS in EHLO response, the client tries to use it. If STARTTLS is not advertised, the clients sends passwords in the plain. You can use `ignoreTLS` and `requireTLS` to change this behavior by explicitly enabling or disabling STARTTLS usage.
 
 ### XOAUTH2
 

--- a/src/smtpclient.js
+++ b/src/smtpclient.js
@@ -616,10 +616,12 @@
         }
 
         // Detect if the server supports STARTTLS
-        if (!this._secureMode && command.line.match(/[ \-]STARTTLS\s?$/mi) && !this.options.ignoreTLS) {
-            this._currentAction = this._actionSTARTTLS;
-            this._sendCommand('STARTTLS');
-            return;
+        if (!this._secureMode) {
+            if (command.line.match(/[ \-]STARTTLS\s?$/mi) && !this.options.ignoreTLS || !!this.options.requireTLS) {
+                this._currentAction = this._actionSTARTTLS;
+                this._sendCommand('STARTTLS');
+                return;
+            }
         }
 
         this._authenticateUser.call(this);
@@ -634,9 +636,8 @@
      */
     SmtpClient.prototype._actionSTARTTLS = function(command) {
         if (!command.success) {
-            // Try HELO instead
-            this._currentAction = this._actionHELO;
-            this._sendCommand('HELO ' + this.options.name);
+            axe.error(DEBUG_TAG, 'STARTTLS not successful');
+            this._onError(new Error(command.data));
             return;
         }
 

--- a/test/integration/smtpclient-test.js
+++ b/test/integration/smtpclient-test.js
@@ -301,3 +301,147 @@ describe('smtpclient authentication tests', function() {
         };
     });
 });
+
+describe('smtpclient STARTTLS tests', function() {
+    var port = 10001,
+        server;
+
+    describe('STARTTLS is supported', function() {
+        before(function(done) {
+            // start smtp test server
+            var options = {
+                debug: false,
+                disableDNSValidation: true,
+                port: port,
+                enableAuthentication: true,
+                secureConnection: false,
+                ignoreTLS: true,
+                authMethods: ["PLAIN", "LOGIN", "XOAUTH2"]
+            };
+
+            server = simplesmtp.createServer(options);
+            server.on('startData', function( /*connection*/ ) {});
+            server.on('data', function( /*connection, chunk*/ ) {});
+            server.on('dataReady', function(connection, callback) {
+                callback(null, 'foo');
+            });
+            server.on('authorizeUser', function(connection, username, password, callback) {
+                callback(null, username === 'abc' && password === 'def');
+            });
+            server.listen(options.port, done);
+        });
+
+        after(function(done) {
+            // close smtp test server
+            server.end(done);
+        });
+
+        it('should connect insecurely', function(done) {
+            var smtp = new SmtpClient('127.0.0.1', port, {
+                useSecureTransport: false,
+                auth: {
+                    user: 'abc',
+                    pass: 'def'
+                },
+                ignoreTLS: true
+            });
+            expect(smtp).to.exist;
+
+            smtp.connect();
+            smtp.onidle = function() {
+                expect(smtp._secureMode).to.be.false;
+                smtp.onclose = done;
+                smtp.quit();
+            };
+        });
+
+        it('should connect securely', function(done) {
+            var smtp = new SmtpClient('127.0.0.1', port, {
+                useSecureTransport: false,
+                auth: {
+                    user: 'abc',
+                    pass: 'def'
+                }
+            });
+            expect(smtp).to.exist;
+
+            smtp.connect();
+            smtp.onidle = function() {
+                expect(smtp._secureMode).to.be.true;
+                smtp.onclose = done;
+                smtp.quit();
+            };
+        });
+    });
+
+    describe('STARTTLS is disabled', function() {
+        before(function(done) {
+            // start smtp test server
+            var options = {
+                debug: false,
+                disableDNSValidation: true,
+                port: port,
+                enableAuthentication: true,
+                secureConnection: false,
+                ignoreTLS: true,
+                authMethods: ["PLAIN", "LOGIN", "XOAUTH2"],
+                disableSTARTTLS: true
+            };
+
+            server = simplesmtp.createServer(options);
+            server.on('startData', function( /*connection*/ ) {});
+            server.on('data', function( /*connection, chunk*/ ) {});
+            server.on('dataReady', function(connection, callback) {
+                callback(null, 'foo');
+            });
+            server.on('authorizeUser', function(connection, username, password, callback) {
+                callback(null, username === 'abc' && password === 'def');
+            });
+            server.listen(options.port, done);
+        });
+
+        after(function(done) {
+            // close smtp test server
+            server.end(done);
+        });
+
+        it('should connect insecurely', function(done) {
+            var smtp = new SmtpClient('127.0.0.1', port, {
+                useSecureTransport: false,
+                auth: {
+                    user: 'abc',
+                    pass: 'def'
+                }
+            });
+            expect(smtp).to.exist;
+
+            smtp.connect();
+            smtp.onidle = function() {
+                expect(smtp._secureMode).to.be.false;
+                smtp.onclose = done;
+                smtp.quit();
+            };
+        });
+
+        it('should fail connecting to insecure server', function(done) {
+            var smtp = new SmtpClient('127.0.0.1', port, {
+                useSecureTransport: false,
+                auth: {
+                    user: 'abc',
+                    pass: 'def'
+                },
+                requireTLS: true
+            });
+            expect(smtp).to.exist;
+
+            smtp.connect();
+
+            smtp.onerror = function(err) {
+                expect(err).to.exist;
+                expect(smtp._secureMode).to.be.false;
+                smtp.onclose = done;
+                smtp.quit();
+            };
+        });
+    });
+});


### PR DESCRIPTION
STARTTLS error handling was buggy anyway – if starttls failed, it tried to do HELO instead which makes no sense. Probably some previous copy-paste mistake.
