### PR TITLE
Do not allow HELO to bypass requireTLS enforcement

### DIFF
--- a/src/smtpclient.js
+++ b/src/smtpclient.js
@@ -629,6 +629,13 @@
         var match;
 
         if (!command.success) {
+            if (!this._secureMode && this.options.requireTLS) {
+                var errMsg = 'STARTTLS not supported without EHLO';
+                axe.error(DEBUG_TAG, errMsg);
+                this._onError(new Error(errMsg));
+                return;
+            }
+
             // Try HELO instead
             axe.warn(DEBUG_TAG, 'EHLO not successful, trying HELO ' + this.options.name);
             this._currentAction = this._actionHELO;


### PR DESCRIPTION
If the server generated an error when EHLO was issued, HELO would be tried,
bypassing the logic at the bottom of the EHLO handler that tries to initiate
STARTTLS.  This would enable an attacker to bypass the protections of
requireTLS.

This fix assumes that if EHLO fails then STARTTLS is inherently not a
possibility and immediately generates an error.
